### PR TITLE
riscv: dts: th1520, lpi4a: add sdhci and rtl8723ds nodes

### DIFF
--- a/arch/riscv/boot/dts/thead/th1520-lichee-module-4a.dtsi
+++ b/arch/riscv/boot/dts/thead/th1520-lichee-module-4a.dtsi
@@ -64,3 +64,27 @@
 	thead,phy-pull-up;
 	status = "okay";
 };
+
+&sdhci0 {
+	bus-width = <4>;
+	max-frequency = <198000000>;
+	thead,phy-pull-up;
+	wprtn_ignore;
+	status = "okay";
+};
+
+&sdhci1 {
+	bus-width = <4>;
+	max-frequency = <100000000>;
+	thead,phy-pull-up;
+	no-sd;
+	no-mmc;
+	non-removable;
+	thead,io-fixed-1v8;
+	post-power-on-delay-ms = <50>;
+	wprtn_ignore;
+	cap-sd-highspeed;
+	keep-power-in-suspend;
+	wakeup-source;
+	status = "okay";
+};

--- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
+++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
@@ -108,6 +108,24 @@
 		enable-active-high;
 		regulator-always-on;
 	};
+
+	wcn_wifi: wireless-wlan {
+		compatible = "wlan-platdata";
+		clock-names = "clk_wifi";
+		ref-clock-frequency = <24000000>;
+		keep_wifi_power_on;
+		pinctrl-names = "default";
+		wifi_chip_type = "rtl8723ds";
+		WIFI,poweren_gpio = <&pca9557_1 5 0>;
+		status = "okay";
+	};
+
+	wcn_bt: wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		pinctrl-names = "default", "rts_gpio";
+		BT,power_gpio    = <&pca9557_1 6 0>;
+		status = "okay";
+	};
 };
 
 &mdio0 {
@@ -135,6 +153,21 @@
 
 &uart0 {
 	status = "okay";
+};
+
+&i2c1 {
+	clock-frequency = <100000>;
+	i2c-sda-hold-time-ns = <300>;
+	i2c-sda-falling-time-ns = <510>;
+	i2c-scl-falling-time-ns = <510>;
+	status = "okay";
+
+	pca9557_1: gpio@18 {
+		compatible = "nxp,pca9557";
+		reg = <0x18>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
 };
 
 &i2c3 {

--- a/arch/riscv/boot/dts/thead/th1520.dtsi
+++ b/arch/riscv/boot/dts/thead/th1520.dtsi
@@ -502,6 +502,24 @@
 			clocks = <&sdhci_clk>;
 			clock-names = "core";
 		};
+		
+		sdhci0: sd@ffe7090000 {
+			compatible = "thead,th1520-dwcmshc";
+			reg = <0xff 0xe7090000 0x0 0x10000>;
+			interrupts = <64 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "sdhci0irq";
+			clocks = <&sdhci_clk>;
+			clock-names = "core";
+		};
+
+		sdhci1: sd@ffe70a0000 {
+		        compatible = "thead,th1520-dwcmshc";
+		        reg = <0xff 0xe70a0000 0x0 0x10000>;
+		        interrupts = <71 IRQ_TYPE_LEVEL_HIGH>;
+		        interrupt-names = "sdhci1irq";
+		        clocks = <&sdhci_clk>;
+		        clock-names = "core";
+		};
 
 		timer0: timer@ffefc32000 {
 			compatible = "snps,dw-apb-timer";


### PR DESCRIPTION
添加设备树节点后：

1.  板载 8723ds 可用
2.  SD 卡槽仍无法使用