### PR TITLE
Th1520 6.6 oot build fix

### DIFF
--- a/drivers/soc/xuantie/nna/img_mem/Makefile
+++ b/drivers/soc/xuantie/nna/img_mem/Makefile
@@ -14,7 +14,7 @@ CFLAGS_img_mem_ion.o += -Idrivers/staging/android/ion
 endif
 
 # IMGMMU: These should be obsoleted
-ccflags-y += -I$(src)/imgmmu/mmulib
+ccflags-y += -I$(srctree)/$(src)/imgmmu/mmulib
 # IMGMMU: code
 img_mem-y                           += imgmmu/imgmmu.o
 img_mem-y                           += imgmmu/kernel_heap.o

--- a/drivers/soc/xuantie/nna/nexef_platform/Makefile
+++ b/drivers/soc/xuantie/nna/nexef_platform/Makefile
@@ -10,8 +10,8 @@ endif
 
 ccflags-y += -I$(CONFIG_NEXEF_NNPU_INCLUDE)
 
-ccflags-y += -I$(src)/../include
-ccflags-y += -I$(src)/
+ccflags-y += -I$(srctree)/$(src)/../include
+ccflags-y += -I$(srctree)/$(src)/
 ccflags-y += -Wall -g
 
 # This should not be needed, but on some platform (especially old kernel)


### PR DESCRIPTION
## Summary by Sourcery

Fix out-of-tree build compatibility by adjusting include paths in xuantie NNA subdirectories and improve panel reset GPIO handling by using the sleeping-capable gpiod_set_value_cansleep API

Enhancements:
- Switch to gpiod_set_value_cansleep in the panel-mingjun-070bi30ia2 driver for the reset GPIO
- Update Makefiles in xuantie NNA nexef_platform and img_mem to use srctree-based include paths