### PR TITLE
drm/verisilicon: properly implement vmap

### DIFF
--- a/drivers/gpu/drm/verisilicon/vs_gem.c
+++ b/drivers/gpu/drm/verisilicon/vs_gem.c
@@ -378,22 +378,32 @@ struct sg_table *vs_gem_prime_get_sg_table(struct drm_gem_object *obj)
 static int vs_gem_prime_vmap(struct drm_gem_object *obj, struct iosys_map *map)
 {
 	struct vs_gem_object *vs_obj = to_vs_gem_object(obj);
-	void *addr = vs_obj->dma_attrs & DMA_ATTR_NO_KERNEL_MAPPING ?
-					page_address(vs_obj->cookie) : vs_obj->cookie;
+	unsigned int nr_pages;
 
-	if (addr == NULL)
+	if (vs_obj->vaddr)
+		goto out;
+
+	nr_pages = vs_obj->size >> PAGE_SHIFT;
+	vs_obj->vaddr = vmap(vs_obj->pages, nr_pages, VM_MAP,
+			     pgprot_writecombine(PAGE_KERNEL));
+
+	if (!vs_obj->vaddr)
 		return -ENOMEM;
 
-	iosys_map_set_vaddr(map, vs_obj->dma_attrs & DMA_ATTR_NO_KERNEL_MAPPING ?
-						page_address(vs_obj->cookie) :
-						vs_obj->cookie);
-
+out:
+	iosys_map_set_vaddr(map, vs_obj->vaddr);
 	return 0;
 }
 
 static void vs_gem_prime_vunmap(struct drm_gem_object *obj, struct iosys_map *map)
 {
-	/* Nothing to do */
+	struct vs_gem_object *vs_obj = to_vs_gem_object(obj);
+
+	if (!vs_obj->vaddr)
+		return;
+
+	vunmap(vs_obj->vaddr);
+	vs_obj->vaddr = NULL;
 }
 
 static const struct vm_operations_struct vs_vm_ops = {

--- a/drivers/gpu/drm/verisilicon/vs_gem.h
+++ b/drivers/gpu/drm/verisilicon/vs_gem.h
@@ -32,6 +32,7 @@ struct vs_gem_object {
 	struct drm_gem_object   base;
 	size_t          size;
 	void            *cookie;
+	void            *vaddr;
 	dma_addr_t      dma_addr;
 	u32             iova;
 	unsigned long   dma_attrs;


### PR DESCRIPTION
On 6.6 kernel, the address returned by dma_alloc_attrs() is directly from the linear mapping and not mapped with the expected page attribute.

Properly implement a vmap (and corresponding vunmap) to ensure the virtual address set by it is mapped with the expect write-combining page attributes.

===============

This PR fixes fbcon refreshing issue on (at least) Lichee Console 4A.

## Summary by Sourcery

Apply proper vmap/vunmap mapping with write-combining attributes for Verisilicon GEM objects to ensure correct kernel mappings and resolve framebuffer refresh issues.

Bug Fixes:
- Fix fbcon refreshing issue on Lichee Console 4A by ensuring memory is mapped with write-combining attributes

Enhancements:
- Implement vmap() in vs_gem_prime_vmap with pgprot_writecombine and corresponding vunmap() in vs_gem_prime_vunmap
- Add a new vaddr field to vs_gem_object to track the virtual mapping
- Replace legacy direct kernel mapping of dma_alloc_attrs() return values to guarantee correct page attributes