### PR TITLE
drm/verisilicon: unconditionally use the DC device as dma_dev

### DIFF
--- a/drivers/gpu/drm/verisilicon/vs_dc.c
+++ b/drivers/gpu/drm/verisilicon/vs_dc.c
@@ -1001,9 +1001,9 @@ static int dc_bind(struct device *dev, struct device *master, void *data)
 	}
 #endif
 
-	ret = vs_drm_iommu_attach_device(drm_dev, dev);
+	ret = vs_drm_dma_attach_device(drm_dev, dev);
 	if (ret < 0) {
-		dev_err(dev, "Failed to attached iommu device.\n");
+		dev_err(dev, "Failed to attached DMA device.\n");
 		goto err_clean_dc;
 	}
 
@@ -1100,7 +1100,7 @@ err_cleanup_planes:
 	drm_for_each_crtc(drm_crtc, drm_dev)
 		vs_crtc_destroy(drm_crtc);
 err_detach_dev:
-	vs_drm_iommu_detach_device(drm_dev, dev);
+	vs_drm_dma_detach_device(drm_dev, dev);
 err_clean_dc:
 	dc_deinit(dev);
 	return ret;
@@ -1112,7 +1112,7 @@ static void dc_unbind(struct device *dev, struct device *master, void *data)
 
 	dc_deinit(dev);
 
-	vs_drm_iommu_detach_device(drm_dev, dev);
+	vs_drm_dma_detach_device(drm_dev, dev);
 }
 
 const struct component_ops dc_component_ops = {

--- a/drivers/gpu/drm/verisilicon/vs_drv.h
+++ b/drivers/gpu/drm/verisilicon/vs_drv.h
@@ -39,10 +39,10 @@ struct vs_drm_private {
 	unsigned int pitch_alignment;
 };
 
-int vs_drm_iommu_attach_device(struct drm_device *drm_dev,
+int vs_drm_dma_attach_device(struct drm_device *drm_dev,
 				struct device *dev);
 
-void vs_drm_iommu_detach_device(struct drm_device *drm_dev,
+void vs_drm_dma_detach_device(struct drm_device *drm_dev,
 				struct device *dev);
 
 void vs_drm_update_pitch_alignment(struct drm_device *drm_dev,


### PR DESCRIPTION
As the display-subsystem is outside of the soc device tree node (where the dma-noncoherent property is added), it's assumed to be coherent, and lead to allocated memory being not properly mapped (still cached).

Unconditionally use the DC device (which is in the soc node) as dma_dev to fix framebuffer mapping issue.

## Summary by Sourcery

Always use the DC device as the DMA device in Verisilicon DRM to ensure proper framebuffer mapping and reflect that change in function naming.

Bug Fixes:
- Fix framebuffer mapping by unconditionally assigning the DC device as dma_dev

Enhancements:
- Rename vs_drm_iommu_attach_device/detach_device to vs_drm_dma_attach_device/detach_device
- Update DC binding code and error messages to use the new DMA attach/detach APIs and unconditionally set/reset priv->dma_dev