### PR TITLE
dts: lichee-pi-4a: fix simple-audio-card name and quantity

### DIFF
--- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
+++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
@@ -341,7 +341,7 @@
 
 	th1520_sound_jack: soundcard@2 {
 		compatible = "simple-audio-card";
-		simple-audio-card,name = "Headphones";
+		simple-audio-card,name = "Analog";
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -355,16 +355,8 @@
 				sound-dai = <&es8156_audio_codec>;
 			};
 		};
-	};
-
-	th1520_sound_input: soundcard@3 {
-		compatible = "simple-audio-card";
-		simple-audio-card,name = "Mic";
-		#address-cells = <1>;
-		#size-cells = <0>;
-
 		simple-audio-card,dai-link@1 {  /* I2S - AUDIO SYS CODEC 7210*/
-			reg = <0>;
+			reg = <1>;
 			format = "i2s";
 			cpu {
 				sound-dai = <&i2s1 0>;

--- a/arch/riscv/boot/dts/thead/th1520-lpi4a-console.dts
+++ b/arch/riscv/boot/dts/thead/th1520-lpi4a-console.dts
@@ -405,16 +405,8 @@
 				sound-dai = <&es8156_audio_codec>;
 			};
 		};
-	};
-
-	th1520_sound_input: soundcard@3 {
-		compatible = "simple-audio-card";
-		simple-audio-card,name = "Mic";
-		#address-cells = <1>;
-		#size-cells = <0>;
-
 		simple-audio-card,dai-link@1 {  /* I2S - AUDIO SYS CODEC 7210*/
-			reg = <0>;
+			reg = <1>;
 			format = "i2s";
 			cpu {
 				sound-dai = <&i2s1 0>;


### PR DESCRIPTION
Both DAC(ES8156) and ADC(ES7210) on I2S1 should in the same node.

## Summary by Sourcery

Merge ES8156 DAC and ES7210 ADC into the same I2S1 simple-audio-card node and correct its name and codec count in lichee-pi-4a DTS files

Bug Fixes:
- Combine DAC and ADC under a single I2S1 audio node in DTS
- Fix simple-audio-card node name and codec quantity in th1520-lichee-pi-4a.dts and th1520-lpi4a-console.dts