### PR TITLE
drm/verisilicon: dw-hdmi-th1520: reject 543.5MHz dotclock

### DIFF
--- a/drivers/gpu/drm/verisilicon/dw_hdmi_tx_phy_gen2.h
+++ b/drivers/gpu/drm/verisilicon/dw_hdmi_tx_phy_gen2.h
@@ -618,6 +618,9 @@ dw_hdmi_tx_phy_gen2_mode_valid(struct dw_hdmi *dw_hdmi, void *data,
 	if ((max_height > 0) && (mode->vdisplay > max_height))
 		return MODE_V_ILLEGAL;
 
+	if (mode->clock >= 543000 && mode->clock < 544000)
+		return MODE_CLOCK_RANGE;
+
 	for (i = 0; i < ARRAY_SIZE(mpll_configs); i++) {
 		if (mode->clock <= mpll_configs[i].pixelclock)
 			return MODE_OK;


### PR DESCRIPTION
ASUS VG34V's preferred mode, 3440x1440@100 at 543.5MHz dot clock, is known to be not properly working on TH1520.

Check the dot clock and reject the specific 543MHz~544MHz range now until more information is known.

## Summary by Sourcery

Bug Fixes:
- Add a check to return MODE_CLOCK_RANGE for dot clocks between 543000 and 544000 kHz